### PR TITLE
Allow frame blocks to be placed on top of each other

### DIFF
--- a/Lava/src/main/java/se/datasektionen/lava/blocks/FrameBlock.java
+++ b/Lava/src/main/java/se/datasektionen/lava/blocks/FrameBlock.java
@@ -6,29 +6,30 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.animal.Pig;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.phys.BlockHitResult;
+import se.datasektionen.lava.setup.Registration;
 
 public class FrameBlock extends Block {
     public FrameBlock() {
-        super(Properties.of(Material.WOOD)
-                .noOcclusion()
-                .strength(2.0f)
-                .requiresCorrectToolForDrops());
+        super(Properties.of(Material.WOOD).noOcclusion().strength(2.0f).requiresCorrectToolForDrops());
     }
 
     @Override
-    public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand,
-                                 BlockHitResult result) {
-        if (!level.isClientSide) {
-                Pig pig = EntityType.PIG.create(level);
-                pig.setPos(pos.getX() + this.RANDOM.nextInt(10) - 5, pos.getY(),
-                        pos.getZ() + this.RANDOM.nextInt(10) - 5);
-                level.addFreshEntity(pig);
-            return InteractionResult.SUCCESS;
+    public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult result) {
+        ItemStack held = player.getItemInHand(hand);
+        if (!level.isClientSide && held.getItem() != Registration.FRAME_BLOCK_ITEM.get()) {
+            Pig pig = EntityType.PIG.create(level);
+            pig.setPos(pos.getX() + this.RANDOM.nextInt(10) - 5, pos.getY(), pos.getZ() + this.RANDOM.nextInt(10) - 5);
+            level.addFreshEntity(pig);
+            return InteractionResult.CONSUME;
+        } else if (held.getItem() == Registration.FRAME_BLOCK_ITEM.get()) {
+            return InteractionResult.PASS;
         }
         return InteractionResult.FAIL;
     }


### PR DESCRIPTION
Fix #19
Allow frame blocks to be placed on top of each other and change from `InteractionResult.SUCESS` to `InteractionResult.CONSUME` because we want to consume the items that are placed. The consume option appears to be buggy, items are depleted from the stack, but when the stack is moved it goes back up, but that is a later problem.